### PR TITLE
Update react-intersection-observer to v9.13.0 and fix imports

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import useInView from 'react-intersection-observer';
+import { useInView } from 'react-intersection-observer';
 import Image from 'next/image';
 import { ExternalLink, Users, TrendingUp, Eye, Gamepad2, ArrowLeft, Calendar, Crown } from 'lucide-react';
 import { AnimatedCounter } from '@/components/animated-counter';

--- a/components/animated-counter.tsx
+++ b/components/animated-counter.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import useInView from 'react-intersection-observer';
+import { useInView } from 'react-intersection-observer';
 
 interface AnimatedCounterProps {
   end: number;

--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import useInView from 'react-intersection-observer';
+import { useInView } from 'react-intersection-observer';
 import { Mail, Clock, MessageSquare, MessageCircle, Twitter, Users, Music } from 'lucide-react';
 import { ContactForm } from './contact-form';
 import { CONTACT_INFO, SOCIAL_LINKS, TEAM_CONTACTS } from '@/lib/constants';

--- a/components/services-section.tsx
+++ b/components/services-section.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import useInView from 'react-intersection-observer';
+import { useInView } from 'react-intersection-observer';
 import Image from 'next/image';
 import { ArrowRight, Check } from 'lucide-react';
 import { SERVICES } from '@/lib/constants';

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "uuid": "^9.0.1",
     "vaul": "^0.7.9",
     "zod": "^3.22.4",
-    "react-intersection-observer": "^3.0.0",
+    "react-intersection-observer": "^9.13.0",
     "next-themes": "^0.2.1",
     "nodemailer": "^6.9.7",
     "@sendgrid/mail": "^7.7.0"


### PR DESCRIPTION
## Summary
This PR fixes the react-intersection-observer compatibility issues that were causing build failures.

## Changes Made
1. **Updated package.json**: Changed `react-intersection-observer` version from `^3.0.0` to `^9.13.0` (latest stable)

2. **Fixed import statements** in the following files:
   - `app/games/page.tsx`
   - `components/animated-counter.tsx`
   - `components/contact-section.tsx`
   - `components/services-section.tsx`

   Changed from: `import useInView from 'react-intersection-observer';`
   To: `import { useInView } from 'react-intersection-observer';`

3. **Verified usage patterns**: All files already use the correct usage pattern:
   ```typescript
   const { ref, inView } = useInView({ triggerOnce: true, threshold: 0.1 });
   ```

## Files Already Correct
- `components/games-section.tsx` - Already had the correct import syntax

## Testing
- ✅ All import statements now use the correct destructured import syntax
- ✅ Package version updated to latest stable release
- ✅ Usage patterns are compatible with v9.13.0

This should resolve the build errors related to react-intersection-observer compatibility.